### PR TITLE
fixed page resizing after orientation change

### DIFF
--- a/Classes/View/PDFKBasicPDFViewer.m
+++ b/Classes/View/PDFKBasicPDFViewer.m
@@ -257,13 +257,14 @@
     return UIBarPositionBottom;
 }
 
-- (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
-{
-    //Invalidate the layouts of the collection views on rotation, and animate the rotation.
-    [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
+-(void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration{
+    [super willAnimateRotationToInterfaceOrientation:toInterfaceOrientation duration:duration];
     
     [_thumbsCollectionView.collectionViewLayout invalidateLayout];
     [_pageCollectionView.collectionViewLayout invalidateLayout];
+    
+    [_pageCollectionView displayPage:_document.currentPage animated:NO];
+    
 }
 
 - (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation

--- a/Classes/View/PDFKBasicPDFViewerSinglePageCollectionView.m
+++ b/Classes/View/PDFKBasicPDFViewerSinglePageCollectionView.m
@@ -87,6 +87,8 @@
     //Get the page number
     NSInteger page = indexPath.row + 1;
     
+    cell.contentView.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
+    
     //Load the content
     cell.pageContentView = [[PDFKPageContentView alloc] initWithFrame:contentSize fileURL:_document.fileURL page:page password:_document.password];
         
@@ -121,12 +123,8 @@
     }
     
     _pageContentView = pageContentView;
-    _pageContentView.translatesAutoresizingMaskIntoConstraints = NO;
+
     [self.contentView addSubview:_pageContentView];
-    
-    NSMutableArray *constraints = [[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[content]|" options:NSLayoutFormatAlignAllBaseline metrics:nil views:@{@"superview": self.contentView, @"content": _pageContentView}] mutableCopy];
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[content]|" options:NSLayoutFormatAlignAllLeft metrics:nil views:@{@"superview": self.contentView, @"content": _pageContentView}]];
-    [self.contentView addConstraints:constraints];
 }
 
 - (void)layoutSubviews

--- a/Classes/View/PDFKPageContentView.m
+++ b/Classes/View/PDFKPageContentView.m
@@ -88,11 +88,13 @@ static inline CGFloat ZoomScaleThatFits(CGSize target, CGSize source)
         {
 			theContainerView = [[UIView alloc] initWithFrame:theContentView.bounds];
             theContainerView.backgroundColor = [UIColor blueColor];
-			theContainerView.autoresizesSubviews = NO;
 			theContainerView.userInteractionEnabled = NO;
 			theContainerView.contentMode = UIViewContentModeRedraw;
-			theContainerView.autoresizingMask = UIViewAutoresizingNone;
 			theContainerView.backgroundColor = [UIColor whiteColor];
+            theContainerView.autoresizesSubviews = YES;
+            theContainerView.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
+            
+            self.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
             
             //Remove autoresizing constraints.
             theContentView.translatesAutoresizingMaskIntoConstraints = NO;


### PR DESCRIPTION
fix of the issue on ReadMe page
> "1) The viewer has trouble handling rotation. Upon rotation the page that is currently displayed on screen does not resize to the proper size. Once you switch pages though, everything is fine." 
Page resizes after rotation now.

![86b01cba87e4fd47e8d9d3d96cb2dda3](https://cloud.githubusercontent.com/assets/3368528/7330006/eb441bc6-eb08-11e4-8edf-ad33c4392974.png)
![0f29dcb7f83fd519498bd9bedf2c72ab](https://cloud.githubusercontent.com/assets/3368528/7330007/eb45403c-eb08-11e4-9fc4-9f894194ab85.png)

The only thing left is to resize thumbs collection view