### PR TITLE
Defaults settings were cut away from loadDocument

### DIFF
--- a/Classes/View/PDFKBasicPDFViewer.m
+++ b/Classes/View/PDFKBasicPDFViewer.m
@@ -115,13 +115,6 @@
     self.view.backgroundColor = [UIColor groupTableViewBackgroundColor];
     
     //Defaults
-    _enableBookmarks = YES;
-    _enableSharing = YES;
-    _enablePrinting = YES;
-    _enableOpening = YES;
-    _enableThumbnailSlider = YES;
-    _enablePreview = YES;
-    _standalone = YES;
     _document = document;
     
     //Create the thumbs view

--- a/M13PDFKit/SamplesTableViewController.m
+++ b/M13PDFKit/SamplesTableViewController.m
@@ -40,6 +40,11 @@
     if ([segue.identifier isEqualToString:@"Basic Sample"]) {
         //Create the document for the viewer when the segue is performed.
         PDFKBasicPDFViewer *viewer = (PDFKBasicPDFViewer *)segue.destinationViewController;
+        viewer.enableBookmarks = YES;
+        viewer.enableOpening = YES;
+        viewer.enablePrinting = YES;
+        viewer.enableSharing = YES;
+        viewer.enableThumbnailSlider = YES;
         
         //Load the document
         PDFKDocument *document = [PDFKDocument documentWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"Wikipedia" ofType:@"pdf"] password:nil];


### PR DESCRIPTION
Settings aren't possible to customize due to persistent replacement in ```(void)loadDocument:(PDFKDocument *)document``` when viewer is presenting. I understand that values need to be set explicitly, but as pointed here http://stackoverflow.com/questions/2919745/default-value-of-bool non-initialized property will be set to NO. So I moved setup away from load method. In this case viewer setup works as expected.