### PR TITLE
Fixed page calculation, added notification block

### DIFF
--- a/Classes/View/PDFKBasicPDFViewer.h
+++ b/Classes/View/PDFKBasicPDFViewer.h
@@ -16,6 +16,8 @@
 #import <UIKit/UIKit.h>
 @class PDFKDocument;
 
+typedef void (^PDFKBasicPDFViewerPageChangeBlock)(NSUInteger page);
+
 @interface PDFKBasicPDFViewer : UIViewController
 
 /**@name Initalization*/
@@ -44,6 +46,8 @@
 - (void)displayPage:(NSUInteger)page;
 
 /**@name Properties*/
+
+@property (nonatomic, strong) PDFKBasicPDFViewerPageChangeBlock pageChangeBlock;
 
 @property (nonatomic, strong, readonly) PDFKDocument *document;
 

--- a/Classes/View/PDFKBasicPDFViewer.m
+++ b/Classes/View/PDFKBasicPDFViewer.m
@@ -453,6 +453,10 @@
     self.document.currentPage = page;
     [self.pageScrubber updateScrubber];
     [self resetNavigationToolbar];
+    
+    if (_pageChangeBlock) {
+        _pageChangeBlock(page);
+    }
 }
 
 - (void)nextPage

--- a/Classes/View/PDFKBasicPDFViewer.m
+++ b/Classes/View/PDFKBasicPDFViewer.m
@@ -435,7 +435,7 @@
 
 - (void)thumbCollectionView:(PDFKBasicPDFViewerThumbsCollectionView *)thumbsCollectionView didSelectPage:(NSUInteger)page
 {
-    [self.pageCollectionView displayPage:page animated:NO];
+    [self.pageCollectionView displayPage:page animated:YES];
     self.document.currentPage = page;
     [self.pageScrubber updateScrubber];
     [self toggleSinglePageView];

--- a/Classes/View/PDFKBasicPDFViewerSinglePageCollectionView.m
+++ b/Classes/View/PDFKBasicPDFViewerSinglePageCollectionView.m
@@ -100,9 +100,16 @@
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
 {
-    //Get the current cell and notify the delegate
-    NSIndexPath *indexPath = [self indexPathsForVisibleItems][0];
-    NSUInteger page = indexPath.row + 1;
+    //Get the current page and notify the delegate
+    NSUInteger page = (scrollView.contentOffset.x + scrollView.frame.size.width) / scrollView.frame.size.width;
+    
+    [_singlePageDelegate singlePageCollectionView:self didDisplayPage:page];
+}
+
+- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
+{
+    //Get the current page and notify the delegate
+    NSUInteger page = (scrollView.contentOffset.x + scrollView.frame.size.width) / scrollView.frame.size.width;
     
     [_singlePageDelegate singlePageCollectionView:self didDisplayPage:page];
 }


### PR DESCRIPTION
Hi,

There were some errors with page calculation and reporting:
1. Method `scrollViewDidEndDecelerating` was called after a touch in UIScrollView. In origin implementation it was connected to `UIGestureRecognizer` and performed page change programatically but in such case `scrollViewDidEndDecelerating` was not called again after animation. Sample discussion can be found here: http://stackoverflow.com/questions/8334566/scrollviewdidenddecelerating-being-called-for-a-simple-touch I added `scrollViewDidEndScrollingAnimation` method that reports page change when such animation is finished. 
2. I changed current page to be calculated based on scroll view content size and frame instead of indexPath as it didn't work properly when scrolled backwards.
3. I also added a block with page number that is called when page change occurs - it allows application to be notified when page change occurs.
